### PR TITLE
Added url validation

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -79,7 +79,7 @@ export default function Home() {
           />
         )}
 
-        {activeTab === "about" && (
+        {activeTab === "abt" && (
           <div className="text-slate-10 text-pretty leading-relaxed">
             {/* About Us content will go here */}
           </div>

--- a/components/header/index.tsx
+++ b/components/header/index.tsx
@@ -20,10 +20,10 @@ export function Header({ activeTab, setActiveTab }: HeaderProps) {
         >
           <div className="flex items-center gap-6 px-6 py-3">
             <button
-              onClick={() => setActiveTab("about")}
-              className={`text-lg font-medium ${activeTab === "about" ? "text-orange-500" : "text-slate-10 hover:text-orange-400"}`}
+              onClick={() => setActiveTab("abt")}
+              className={`text-lg font-medium ${activeTab === "abt" ? "text-orange-500" : "text-slate-10 hover:text-orange-400"}`}
             >
-              about
+              abt
             </button>
             <button
               onClick={() => setActiveTab("url")}

--- a/components/url-shortener-form.tsx
+++ b/components/url-shortener-form.tsx
@@ -45,7 +45,7 @@ export function UrlShortenerForm({ isAliasValid, url, setUrl, resetParentForm }:
     if (!isValidHttpUrl(url)){
       toast({
         title: "Invalid URL",
-        description: "Please enter a valid https(s) link.",
+        description: "Please enter a valid http(s) link.",
         variant: "destructive",
       })
       return;

--- a/components/url-shortener-form.tsx
+++ b/components/url-shortener-form.tsx
@@ -22,6 +22,12 @@ export function UrlShortenerForm({ isAliasValid, url, setUrl, resetParentForm }:
   const qrCodeRef = useRef<HTMLDivElement>(null)
   const { toast } = useToast()
 
+  function isValidHttpUrl(value: string): boolean {
+    const regex = /^(https?:\/\/)([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}(\/[^\s]*)?$/;
+    return regex.test(value.trim());
+  }
+
+
   const handleShorten = async (e: React.FormEvent) => {
     e.preventDefault()
     console.log("handleShorten called"); // Debug log
@@ -33,6 +39,15 @@ export function UrlShortenerForm({ isAliasValid, url, setUrl, resetParentForm }:
         description: "Your custom alias contains inappropriate words.",
         variant: "destructive",
       });
+      return;
+    }
+
+    if (!isValidHttpUrl(url)){
+      toast({
+        title: "Invalid URL",
+        description: "Please enter a valid https(s) link.",
+        variant: "destructive",
+      })
       return;
     }
 


### PR DESCRIPTION
I've used regular expressions to do the url validation

^(https?:\/\/)([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}(\/[^\s]*)?$

- Checks if the url starts with http:// or https://
- Accepts alphabets and hyphens
- A dot
- Compulsory 2 alphabets, and then allows any number of characters

Ensures the url is at least like https://domain.co 