### PR TITLE
Feature: QR Customisations

### DIFF
--- a/components/qr-code-generator.tsx
+++ b/components/qr-code-generator.tsx
@@ -39,6 +39,7 @@ export function QrCodeGenerator({
   const [frameLabel, setFrameLabel] = useState("Scan Me");
   const [frameLabelColor, setFrameLabelColor] = useState("#FFFFFF");
   const [showCustomize, setShowCustomize] = useState(false);
+  const [addPadding, setAddPadding] = useState(false);
 
   const frameLabelSize = 24;
 
@@ -49,13 +50,16 @@ export function QrCodeGenerator({
     if (!svgElement) return;
 
     const qrSize = 180;
-    const padding = 16; // p-2 = 8px * 2
-    const frameExtraPadding = showFrame ? 24 : 0;
-    const frameLabelHeight = showFrame && frameLabel.trim() ? 36 : 0;
-
-    const canvasWidth = qrSize + padding + frameExtraPadding;
-    const canvasHeight =
-      qrSize + padding + frameExtraPadding + frameLabelHeight;
+    const padding = addPadding ? 16 : 0; // p-2 = 8px * 2
+    const framePadding = showFrame ? 12 : 0; // p-3 = 12px
+    const gap = 8; // gap-2 = 8px
+    const hasLabel = showFrame && frameLabel.trim().length > 0;
+    
+    const qrBoxSize = qrSize + padding;
+    const canvasWidth = qrBoxSize + (framePadding * 2);
+    const canvasHeight = showFrame
+        ? framePadding + qrBoxSize + (hasLabel ? gap + frameLabelSize : 0) + framePadding
+        : qrBoxSize;
 
     const canvas = document.createElement("canvas");
     const scale = 3; // High-res export
@@ -74,11 +78,11 @@ export function QrCodeGenerator({
     }
 
     // Draw QR background
-    const qrX = (canvasWidth - qrSize - padding) / 2;
-    const qrY = showFrame ? frameExtraPadding / 2 : 0;
+    const qrX = framePadding;
+    const qrY = framePadding;
     ctx.fillStyle = bgColor;
     ctx.beginPath();
-    ctx.roundRect(qrX, qrY, qrSize + padding, qrSize + padding, 8);
+    ctx.roundRect(qrX, qrY, qrBoxSize, qrBoxSize, 8);
     ctx.fill();
 
     // Draw QR code SVG
@@ -88,7 +92,7 @@ export function QrCodeGenerator({
       ctx.drawImage(img, qrX + padding / 2, qrY + padding / 2, qrSize, qrSize);
 
       // Draw frame label
-      if (showFrame && frameLabel.trim()) {
+      if (hasLabel) {
         ctx.fillStyle = frameLabelColor;
         ctx.font = `bold ${frameLabelSize}px sans-serif`;
         ctx.textAlign = "center";
@@ -96,7 +100,7 @@ export function QrCodeGenerator({
         ctx.fillText(
           frameLabel,
           canvasWidth / 2,
-          canvasHeight - frameLabelHeight / 2,
+          qrY + qrBoxSize + gap + (frameLabelSize / 2)
         );
       }
 
@@ -105,7 +109,7 @@ export function QrCodeGenerator({
     img.src =
       "data:image/svg+xml;base64," +
       btoa(unescape(encodeURIComponent(svgData)));
-  }, [bgColor, frameColor, frameLabel, frameLabelColor, showFrame]);
+  }, [bgColor, frameColor, frameLabel, frameLabelColor, showFrame, addPadding]);
 
   useEffect(() => {
     if (url && showQrCode) {
@@ -122,6 +126,7 @@ export function QrCodeGenerator({
     frameColor,
     frameLabel,
     frameLabelColor,
+    addPadding,
     generateQrCodeImage,
   ]);
 
@@ -237,22 +242,11 @@ export function QrCodeGenerator({
           <div
             ref={qrCodeRef}
             onClick={() => qrCodeDataUrl && copyQrCodeToClipboard()}
-            className={`relative flex flex-col items-center cursor-pointer [&:hover>.copy-overlay]:opacity-100 ${showFrame ? "rounded-xl" : "rounded-lg"}`}
-            style={
-              showFrame
-                ? {
-                  backgroundColor: frameColor,
-                  borderRadius: "12px",
-                  padding:
-                    "12px 12px " +
-                    (frameLabel.trim() ? "4px" : "12px") +
-                    " 12px",
-                }
-                : undefined
-            }
+            className={`relative flex flex-col items-center cursor-pointer transition-all [&:hover>.copy-overlay]:opacity-100 ${showFrame ? "p-3 rounded-xl gap-2" : "rounded-lg"}`}
+            style={showFrame ? { backgroundColor: frameColor } : undefined}
           >
             <div
-              className="relative p-2 rounded-lg"
+              className={`relative ${addPadding ? "p-2" : "p-0"} rounded-lg`}
               style={{ backgroundColor: bgColor }}
             >
               <QRCode
@@ -265,10 +259,11 @@ export function QrCodeGenerator({
             {/* Frame label */}
             {showFrame && frameLabel.trim() && (
               <p
-                className="font-bold mt-1 mb-1 text-center select-none"
+                className="font-bold text-center select-none"
                 style={{
                   color: frameLabelColor,
                   fontSize: `${frameLabelSize}px`,
+                  lineHeight: `${frameLabelSize}px`,
                 }}
               >
                 {frameLabel}
@@ -318,25 +313,45 @@ export function QrCodeGenerator({
                 </div>
               </div>
 
-              {/* ── Frame ── */}
+              {/* ── Options ── */}
               <div className="flex flex-col gap-2">
-                <div className="flex items-center justify-between">
-                  <input
-                    type="checkbox"
-                    id="show-frame"
-                    checked={showFrame}
-                    onChange={(e) => setShowFrame(e.target.checked)}
-                    className="w-4 h-4 shrink-0 rounded cursor-pointer accent-orange-500"
-                  />
-                  <label
-                    htmlFor="show-frame"
-                    className="text-xs text-orange-600 dark:text-orange-400 font-semibold uppercase tracking-wider cursor-pointer select-none"
-                  >
-                    Frame
-                  </label>
+                <p className="text-xs text-orange-600 dark:text-orange-400 font-semibold uppercase tracking-wider">
+                  Options
+                </p>
+                <div className="flex flex-col gap-3">
+                  <div className="flex items-center justify-between">
+                    <label
+                      htmlFor="add-padding"
+                      className="text-xs text-slate-11 font-medium text-left cursor-pointer select-none"
+                    >
+                      Add Padding
+                    </label>
+                    <input
+                      type="checkbox"
+                      id="add-padding"
+                      checked={addPadding}
+                      onChange={(e) => setAddPadding(e.target.checked)}
+                      className="w-4 h-4 shrink-0 rounded cursor-pointer accent-orange-500 bg-gray-11/5 border border-gray-11/20"
+                    />
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <label
+                      htmlFor="show-frame"
+                      className="text-xs text-slate-11 font-medium text-left cursor-pointer select-none"
+                    >
+                      Enable Frame
+                    </label>
+                    <input
+                      type="checkbox"
+                      id="show-frame"
+                      checked={showFrame}
+                      onChange={(e) => setShowFrame(e.target.checked)}
+                      className="w-4 h-4 shrink-0 rounded cursor-pointer accent-orange-500 bg-gray-11/5 border border-gray-11/20"
+                    />
+                  </div>
                 </div>
                 {showFrame && (
-                  <div className="flex flex-col gap-3 border-l-2 border-orange-300 dark:border-orange-700 pl-4 animate-in fade-in-50 duration-200">
+                  <div className="flex flex-col gap-3 border-l-2 border-orange-300 dark:border-orange-700 pl-4 pt-1 animate-in fade-in-50 duration-200">
                     {/* Frame Color */}
                     <ColorInputRow
                       label="Frame Color"

--- a/components/qr-code-generator.tsx
+++ b/components/qr-code-generator.tsx
@@ -1,61 +1,142 @@
-"use client"
+"use client";
 
-import { useState, useRef, useEffect } from "react"
-import type React from "react"
-import QRCode from "react-qr-code"
-import { useToast } from "@/hooks/use-toast"
-import { Download, Copy, ArrowLeft } from "lucide-react" // Import Copy and ArrowLeft icons
+import { useState, useRef, useEffect, useCallback } from "react";
+import type React from "react";
+import QRCode from "react-qr-code";
+import { useToast } from "@/hooks/use-toast";
+import {
+  Download,
+  Copy,
+  ArrowLeft,
+  ChevronDown,
+  ChevronUp,
+} from "lucide-react";
+import { ColorInputRow } from "./ui/ColorInputRow";
+import { TextInputRow } from "./ui/TextInputRow";
+
+
 interface QrCodeGeneratorProps {
   url: string;
   setUrl: React.Dispatch<React.SetStateAction<string>>;
   isValidHttpUrl: (alias: string) => boolean;
 }
 
-export function QrCodeGenerator({ url, setUrl, isValidHttpUrl }: QrCodeGeneratorProps) {
-  const [qrCodeDataUrl, setQrCodeDataUrl] = useState("")
-  const [showQrCode, setShowQrCode] = useState(false) // New state to control QR code visibility
-  const qrCodeRef = useRef<HTMLDivElement>(null)
-  const { toast } = useToast()
+export function QrCodeGenerator({
+  url,
+  setUrl,
+  isValidHttpUrl,
+}: QrCodeGeneratorProps) {
+  const [qrCodeDataUrl, setQrCodeDataUrl] = useState("");
+  const [showQrCode, setShowQrCode] = useState(false);
+  const qrCodeRef = useRef<HTMLDivElement>(null);
+  const { toast } = useToast();
 
-  const generateQrCodeImage = () => {
-    if (qrCodeRef.current) {
-      const svgElement = qrCodeRef.current.querySelector('svg');
-      if (svgElement) {
-        const svgData = new XMLSerializer().serializeToString(svgElement);
-        const canvas = document.createElement('canvas');
-        const ctx = canvas.getContext('2d');
-        const img = new Image();
+  // Customization state
+  const [fgColor, setFgColor] = useState("#000000");
+  const [bgColor, setBgColor] = useState("#FFFFFF");
+  const [showFrame, setShowFrame] = useState(false);
+  const [frameColor, setFrameColor] = useState("#f97316");
+  const [frameLabel, setFrameLabel] = useState("Scan Me");
+  const [frameLabelColor, setFrameLabelColor] = useState("#FFFFFF");
+  const [showCustomize, setShowCustomize] = useState(false);
 
-        img.onload = () => {
-          canvas.width = img.width;
-          canvas.height = img.height;
-          ctx?.drawImage(img, 0, 0);
-          setQrCodeDataUrl(canvas.toDataURL('image/png'));
-        };
-        img.src = 'data:image/svg+xml;base64,' + btoa(svgData);
-      }
+  const frameLabelSize = 24;
+
+  const generateQrCodeImage = useCallback(() => {
+    if (!qrCodeRef.current) return;
+
+    const svgElement = qrCodeRef.current.querySelector("svg");
+    if (!svgElement) return;
+
+    const qrSize = 180;
+    const padding = 16; // p-2 = 8px * 2
+    const frameExtraPadding = showFrame ? 24 : 0;
+    const frameLabelHeight = showFrame && frameLabel.trim() ? 36 : 0;
+
+    const canvasWidth = qrSize + padding + frameExtraPadding;
+    const canvasHeight =
+      qrSize + padding + frameExtraPadding + frameLabelHeight;
+
+    const canvas = document.createElement("canvas");
+    const scale = 3; // High-res export
+    canvas.width = canvasWidth * scale;
+    canvas.height = canvasHeight * scale;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+    ctx.scale(scale, scale);
+
+    // Draw frame background if enabled
+    if (showFrame) {
+      ctx.fillStyle = frameColor;
+      ctx.beginPath();
+      ctx.roundRect(0, 0, canvasWidth, canvasHeight, 12);
+      ctx.fill();
     }
-  };
+
+    // Draw QR background
+    const qrX = (canvasWidth - qrSize - padding) / 2;
+    const qrY = showFrame ? frameExtraPadding / 2 : 0;
+    ctx.fillStyle = bgColor;
+    ctx.beginPath();
+    ctx.roundRect(qrX, qrY, qrSize + padding, qrSize + padding, 8);
+    ctx.fill();
+
+    // Draw QR code SVG
+    const svgData = new XMLSerializer().serializeToString(svgElement);
+    const img = new Image();
+    img.onload = () => {
+      ctx.drawImage(img, qrX + padding / 2, qrY + padding / 2, qrSize, qrSize);
+
+      // Draw frame label
+      if (showFrame && frameLabel.trim()) {
+        ctx.fillStyle = frameLabelColor;
+        ctx.font = `bold ${frameLabelSize}px sans-serif`;
+        ctx.textAlign = "center";
+        ctx.textBaseline = "middle";
+        ctx.fillText(
+          frameLabel,
+          canvasWidth / 2,
+          canvasHeight - frameLabelHeight / 2,
+        );
+      }
+
+      setQrCodeDataUrl(canvas.toDataURL("image/png"));
+    };
+    img.src =
+      "data:image/svg+xml;base64," +
+      btoa(unescape(encodeURIComponent(svgData)));
+  }, [bgColor, frameColor, frameLabel, frameLabelColor, showFrame]);
 
   useEffect(() => {
-    if (url && showQrCode) { // Only generate if URL is present and showQrCode is true
-      generateQrCodeImage();
+    if (url && showQrCode) {
+      // Small delay to let SVG render with new props
+      const timeout = setTimeout(() => generateQrCodeImage(), 100);
+      return () => clearTimeout(timeout);
     }
-  }, [url, showQrCode]); // Depend on showQrCode as well
+  }, [
+    url,
+    showQrCode,
+    fgColor,
+    bgColor,
+    showFrame,
+    frameColor,
+    frameLabel,
+    frameLabelColor,
+    generateQrCodeImage,
+  ]);
 
   const handleGenerateQrCode = async () => {
-    if (!isValidHttpUrl(url)){
+    if (!isValidHttpUrl(url)) {
       toast({
         title: "Invalid URL",
         description: "Please enter a valid http(s) link.",
         variant: "destructive",
-      })
+      });
       return;
     }
 
     if (url) {
       setShowQrCode(true);
-      // The QR code generation and copy to clipboard will now be handled by the useEffect hooks
     } else {
       toast({
         title: "Error",
@@ -67,9 +148,9 @@ export function QrCodeGenerator({ url, setUrl, isValidHttpUrl }: QrCodeGenerator
 
   const downloadQrCode = () => {
     if (qrCodeDataUrl) {
-      const link = document.createElement('a');
+      const link = document.createElement("a");
       link.href = qrCodeDataUrl;
-      link.download = 'qrcode.png';
+      link.download = "qrcode.png";
       document.body.appendChild(link);
       link.click();
       document.body.removeChild(link);
@@ -93,8 +174,8 @@ export function QrCodeGenerator({ url, setUrl, isValidHttpUrl }: QrCodeGenerator
         const blob = await response.blob();
         await navigator.clipboard.write([
           new ClipboardItem({
-            'image/png': blob
-          })
+            "image/png": blob,
+          }),
         ]);
         toast({
           title: "QR Code Copied!",
@@ -119,8 +200,7 @@ export function QrCodeGenerator({ url, setUrl, isValidHttpUrl }: QrCodeGenerator
 
   return (
     <div className="w-full space-y-6 relative">
-      {/* <div className="space-y-3"> */}
-      <form 
+      <form
         onSubmit={(e) => {
           e.preventDefault();
           handleGenerateQrCode();
@@ -132,7 +212,7 @@ export function QrCodeGenerator({ url, setUrl, isValidHttpUrl }: QrCodeGenerator
           value={url}
           onChange={(e) => {
             setUrl(e.target.value);
-            setShowQrCode(false); // Hide QR code when URL changes
+            setShowQrCode(false);
           }}
           placeholder="Paste your long URL here..."
           className="w-full px-4 py-3 bg-gray-11/5 border border-gray-11/10 rounded-xl text-slate-12 placeholder:text-gray-9 focus:outline-none focus:ring-2 focus:ring-orange-500/20 focus:border-orange-500/30 transition-all"
@@ -146,22 +226,144 @@ export function QrCodeGenerator({ url, setUrl, isValidHttpUrl }: QrCodeGenerator
           Generate QR Code
         </button>
       </form>
-      {/* </div> */}
 
-      {showQrCode && url && ( // Only show QR code if showQrCode is true and URL is present
-        <div className="relative bg-gradient-to-r from-orange-50 to-orange-100 dark:from-orange-950/20 dark:to-orange-900/20 border border-orange-200 dark:border-orange-800/30 rounded-xl p-4 flex flex-col items-center justify-center space-y-3 animate-in fade-in-50 slide-in-from-bottom-4 duration-500">
-          <p className="text-xs text-orange-600 dark:text-orange-400 font-medium mb-1">QR Code for: {url}</p>
-          <div ref={qrCodeRef} className="relative p-2 bg-white rounded-lg group">
-            <QRCode value={url} size={180} />
-            <button
-              onClick={copyQrCodeToClipboard}
-              disabled={!qrCodeDataUrl}
-              className="absolute inset-0 flex items-center justify-center bg-black bg-opacity-50 text-white opacity-0 group-hover:opacity-100 transition-opacity duration-200 rounded-lg cursor-pointer disabled:cursor-not-allowed"
-              aria-label="Copy QR Code"
+      {showQrCode && url && (
+        <div className="relative bg-gradient-to-r from-orange-50 to-orange-100 dark:from-orange-950/20 dark:to-orange-900/20 border border-orange-200 dark:border-orange-800/30 rounded-xl p-5 flex flex-col items-center justify-center space-y-4 animate-in fade-in-50 slide-in-from-bottom-4 duration-500">
+          <p className="text-xs text-orange-600 dark:text-orange-400 font-medium">
+            QR Code for: {url}
+          </p>
+
+          {/* QR Code Preview — click to copy */}
+          <div
+            ref={qrCodeRef}
+            onClick={() => qrCodeDataUrl && copyQrCodeToClipboard()}
+            className={`relative flex flex-col items-center cursor-pointer [&:hover>.copy-overlay]:opacity-100 ${showFrame ? "rounded-xl" : "rounded-lg"}`}
+            style={
+              showFrame
+                ? {
+                  backgroundColor: frameColor,
+                  borderRadius: "12px",
+                  padding:
+                    "12px 12px " +
+                    (frameLabel.trim() ? "4px" : "12px") +
+                    " 12px",
+                }
+                : undefined
+            }
+          >
+            <div
+              className="relative p-2 rounded-lg"
+              style={{ backgroundColor: bgColor }}
             >
+              <QRCode
+                value={url}
+                size={180}
+                fgColor={fgColor}
+                bgColor={bgColor}
+              />
+            </div>
+            {/* Frame label */}
+            {showFrame && frameLabel.trim() && (
+              <p
+                className="font-bold mt-1 mb-1 text-center select-none"
+                style={{
+                  color: frameLabelColor,
+                  fontSize: `${frameLabelSize}px`,
+                }}
+              >
+                {frameLabel}
+              </p>
+            )}
+            {/* Copy overlay */}
+            <div className={`copy-overlay absolute inset-0 flex items-center justify-center bg-black/50 text-white opacity-0 transition-opacity duration-200 ${showFrame ? "rounded-xl" : "rounded-lg"}`}>
               <Copy className="w-8 h-8" />
-            </button>
+            </div>
           </div>
+
+          {/* Customize toggle */}
+          <button
+            type="button"
+            onClick={() => setShowCustomize(!showCustomize)}
+            className="flex items-center gap-1.5 text-sm text-orange-600 dark:text-orange-400 font-medium hover:text-orange-700 dark:hover:text-orange-300 transition-colors"
+          >
+            {showCustomize ? (
+              <ChevronUp className="w-4 h-4" />
+            ) : (
+              <ChevronDown className="w-4 h-4" />
+            )}
+            Customize Design
+          </button>
+
+          {/* Customization controls */}
+          {showCustomize && (
+            <div className="w-full flex flex-col gap-4 overflow-hidden animate-in fade-in-50 slide-in-from-top-2 duration-300">
+              {/* ── Colors ── */}
+              <div className="flex flex-col gap-2">
+                <p className="text-xs text-orange-600 dark:text-orange-400 font-semibold uppercase tracking-wider">
+                  Colors
+                </p>
+                <div className="flex flex-col gap-3">
+                  {/* QR Color */}
+                  <ColorInputRow
+                    label="QR Color"
+                    color={fgColor}
+                    onChange={setFgColor}
+                  />
+                  {/* Background */}
+                  <ColorInputRow
+                    label="Background"
+                    color={bgColor}
+                    onChange={setBgColor}
+                  />
+                </div>
+              </div>
+
+              {/* ── Frame ── */}
+              <div className="flex flex-col gap-2">
+                <div className="flex items-center justify-between">
+                  <input
+                    type="checkbox"
+                    id="show-frame"
+                    checked={showFrame}
+                    onChange={(e) => setShowFrame(e.target.checked)}
+                    className="w-4 h-4 shrink-0 rounded cursor-pointer accent-orange-500"
+                  />
+                  <label
+                    htmlFor="show-frame"
+                    className="text-xs text-orange-600 dark:text-orange-400 font-semibold uppercase tracking-wider cursor-pointer select-none"
+                  >
+                    Frame
+                  </label>
+                </div>
+                {showFrame && (
+                  <div className="flex flex-col gap-3 border-l-2 border-orange-300 dark:border-orange-700 pl-4 animate-in fade-in-50 duration-200">
+                    {/* Frame Color */}
+                    <ColorInputRow
+                      label="Frame Color"
+                      color={frameColor}
+                      onChange={setFrameColor}
+                    />
+                    {/* Label Text */}
+                    <TextInputRow
+                      label="Label Text"
+                      value={frameLabel}
+                      onChange={setFrameLabel}
+                      placeholder="Scan Me"
+                      maxLength={20}
+                    />
+                    {/* Text Color */}
+                    <ColorInputRow
+                      label="Text Color"
+                      color={frameLabelColor}
+                      onChange={setFrameLabelColor}
+                    />
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
+
+          {/* Action buttons */}
           <div className="flex w-full gap-2">
             <button
               onClick={downloadQrCode}
@@ -184,5 +386,5 @@ export function QrCodeGenerator({ url, setUrl, isValidHttpUrl }: QrCodeGenerator
         </div>
       )}
     </div>
-  )
+  );
 }

--- a/components/ui/ColorInputRow.tsx
+++ b/components/ui/ColorInputRow.tsx
@@ -1,0 +1,34 @@
+export function ColorInputRow({
+    label,
+    color,
+    onChange,
+}: {
+    label: string;
+    color: string;
+    onChange: (value: string) => void;
+}) {
+    return (
+        <div className="flex items-center justify-between">
+            <span className="text-xs text-slate-11 font-medium text-left">
+                {label}
+            </span>
+            <div className="flex items-center border border-gray-11/10 rounded-lg overflow-hidden bg-gray-11/5 focus-within:ring-2 focus-within:ring-orange-500/20 focus-within:border-orange-500/30 transition-all">
+                <input
+                    type="color"
+                    value={color}
+                    onChange={(e) => onChange(e.target.value)}
+                    className="w-9 h-9 shrink-0 cursor-pointer bg-transparent border-0 rounded-full p-0.5"
+                />
+                <input
+                    type="text"
+                    value={color}
+                    onChange={(e) => {
+                        const v = e.target.value;
+                        if (/^#[0-9A-Fa-f]{0,6}$/.test(v)) onChange(v);
+                    }}
+                    className="w-20 px-2 py-2 bg-transparent text-slate-12 text-xs font-mono focus:outline-none"
+                />
+            </div>
+        </div>
+    );
+}

--- a/components/ui/TextInputRow.tsx
+++ b/components/ui/TextInputRow.tsx
@@ -1,0 +1,29 @@
+export function TextInputRow({
+    label,
+    value,
+    onChange,
+    placeholder,
+    maxLength,
+}: {
+    label: string;
+    value: string;
+    onChange: (value: string) => void;
+    placeholder?: string;
+    maxLength?: number;
+}) {
+    return (
+        <div className="flex items-center justify-between">
+            <span className="text-xs text-slate-11 font-medium text-left">
+                {label}
+            </span>
+            <input
+                type="text"
+                value={value}
+                onChange={(e) => onChange(e.target.value)}
+                placeholder={placeholder}
+                maxLength={maxLength}
+                className="w-[130px] px-3 py-2 bg-gray-11/5 border border-gray-11/10 rounded-lg text-slate-12 text-xs focus:outline-none focus:ring-2 focus:ring-orange-500/20 focus:border-orange-500/30 transition-all text-left"
+            />
+        </div>
+    );
+}


### PR DESCRIPTION
Since the QR section currently does not provide any customization options, I created a sample interface that allows basic customization such as changing the QR code color, background color, adding a frame, modifying the frame color, and setting a text label for the frame.

Also the resolution of the downloaded qr was poor.

(I had Prettier enabled by default in my Zed editor, so i formatted the code. Sorry if it makes inconvenience.)

# Implementation:
- **QR Colors**: 
The `react-qr-code` library already supports colors, so I just added state variables and color pickers for the user to control them.

- **Frames**: 
To show the frame on the screen, I wrapped the QR code inside a styled box (`div`) that changes color and padding based on what the user selects. I placed the text label right below it.

- **Exporting**:
To make sure the downloaded image actually includes the frame and text, I used an HTML Canvas. I draw the coloured frame background, paste the QR code on top of it, and write the text. Then I save that whole canvas as the final image.

- **Cleanup**: 
I separated the form inputs into their own small, reusable components (`ColorInputRow` and `TextInputRow`) so the main code stays clean and easy to read. 

# Output:

| Before | After |
|:---:|:---:|
|<img width="180" height="180" alt="qrcode (4)" src="https://github.com/user-attachments/assets/cfc5c389-2e8e-49ca-a0d8-a12ad58b7c83" />|<img width="180" height="180" alt="qrcode" src="https://github.com/user-attachments/assets/f22940d2-937d-47ef-92bf-a08b419f2e0a" />|

# Customisations:

| Option | Output |
|:---:|:---:|
| Padding |<img width="180"  alt="qrcode (1)" src="https://github.com/user-attachments/assets/d5a23ca5-6f79-464a-92e1-c71266fa4157" />|
| Frame | <img width="180"  alt="qrcode (2)" src="https://github.com/user-attachments/assets/2dfccf31-bf42-4a47-acfc-35beda3c539d" />|
| Color | <img width="180"  alt="qrcode (3)" src="https://github.com/user-attachments/assets/19d2bf11-9a34-407b-b5ce-6df03c0aadd5" />| 


# Screenshots:

## Before:
<img width="1710" height="1008" alt="Screenshot 2026-03-15 at 11 12 26 AM" src="https://github.com/user-attachments/assets/ba3a1f62-c757-4202-9554-1a92e437f080" />


## After:

Video:


https://github.com/user-attachments/assets/d11a0c53-638a-4eb8-86fa-82b48d292fe4




Images:

<img width="1710" height="1008" alt="Screenshot 2026-03-15 at 1 02 16 PM" src="https://github.com/user-attachments/assets/a1f7a492-99de-432b-81bf-deba832f8595" />
<img width="1710" height="1008" alt="Screenshot 2026-03-15 at 1 00 05 PM" src="https://github.com/user-attachments/assets/efcc7943-f780-49a5-8d9e-33a6c1c062f4" />
<img width="1710" height="1008" alt="Screenshot 2026-03-15 at 1 00 28 PM" src="https://github.com/user-attachments/assets/2e48fe11-3c42-4b09-958c-441f9428bf3f" />
<img width="1710" height="1008" alt="Screenshot 2026-03-15 at 1 03 44 PM" src="https://github.com/user-attachments/assets/bdff2940-924f-408d-bfa3-815bf3c4de20" />



